### PR TITLE
Switch pyimgui submodule URL from SSH to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://gitlab.com/libeigen/eigen.git
 [submodule "thirdparty/in3d/thirdparty/pyimgui"]
 	path = thirdparty/in3d/thirdparty/pyimgui
-	url = git@github.com:pyimgui/pyimgui.git
+	url = https://github.com/pyimgui/pyimgui.git


### PR DESCRIPTION
Update the pyimgui submodule URL in .gitmodules from SSH to HTTPS. This change prevents SSH authentication errors and simplifies cloning for contributors.