### PR TITLE
Refactor camera intrinsics config with YAML inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ python main.py --dataset <path/to/folder> --config config/base.yaml
 ```
 If the calibration parameters are known, you can specify them in intrinsics.yaml
 ```
-python main.py --dataset <path/to/video>.mp4 --config config/base.yaml --calib config/intrinsics.yaml
-python main.py --dataset <path/to/folder> --config config/base.yaml --calib config/intrinsics.yaml
+python main.py --dataset <path/to/video>.mp4 --config config/intrinsics.yaml
+python main.py --dataset <path/to/folder> --config config/intrinsics.yaml
 ```
 
 ## Downloading Dataset

--- a/config/intrinsics.yaml
+++ b/config/intrinsics.yaml
@@ -1,6 +1,7 @@
-width: 640
-height: 480
-# With distortion (fx, fy, cx, cy, k1, k2, p1, p2)
+inherit: "config/base.yaml"
+
+use_calib: True
+# With distortion (fx, fy, cx, cy, k1, k2, p1, p2, k3)
 calibration:  [517.3, 516.5, 318.6, 255.3, 0.2624, -0.9531, -0.0054, 0.0026, 1.1633]
 
 # Without distortion (fx, fy, cx, cy)

--- a/main.py
+++ b/main.py
@@ -155,7 +155,6 @@ if __name__ == "__main__":
     parser.add_argument("--config", default="config/base.yaml")
     parser.add_argument("--save-as", default="default")
     parser.add_argument("--no-viz", action="store_true")
-    parser.add_argument("--calib", default="")
 
     args = parser.parse_args()
 
@@ -169,18 +168,14 @@ if __name__ == "__main__":
 
     dataset = load_dataset(args.dataset)
     dataset.subsample(config["dataset"]["subsample"])
-    h, w = dataset.get_img_shape()[0]
+    (resized_h, resized_w), (raw_h, raw_w) = dataset.get_img_shape()
 
-    if args.calib:
-        with open(args.calib, "r") as f:
-            intrinsics = yaml.load(f, Loader=yaml.SafeLoader)
-        config["use_calib"] = True
-        dataset.use_calibration = True
+    if "calibration" in config.keys():
         dataset.camera_intrinsics = Intrinsics.from_calib(
             dataset.img_size,
-            intrinsics["width"],
-            intrinsics["height"],
-            intrinsics["calibration"],
+            raw_w,
+            raw_h,
+            config["calibration"],
         )
 
     keyframes = SharedKeyframes(manager, h, w)

--- a/mast3r_slam/dataloader.py
+++ b/mast3r_slam/dataloader.py
@@ -202,7 +202,6 @@ class RealsenseDataset(MonocularDataset):
 class Webcam(MonocularDataset):
     def __init__(self):
         super().__init__()
-        self.use_calibration = False
         self.dataset_path = None
         # load webcam using opencv
         self.cap = cv2.VideoCapture(-1)
@@ -227,7 +226,6 @@ class Webcam(MonocularDataset):
 class MP4Dataset(MonocularDataset):
     def __init__(self, dataset_path):
         super().__init__()
-        self.use_calibration = False
         self.dataset_path = pathlib.Path(dataset_path)
         self.decoder = VideoDecoder(str(self.dataset_path))
         self.fps = self.decoder.metadata.average_fps
@@ -250,7 +248,6 @@ class MP4Dataset(MonocularDataset):
 class RGBFiles(MonocularDataset):
     def __init__(self, dataset_path):
         super().__init__()
-        self.use_calibration = False
         self.dataset_path = pathlib.Path(dataset_path)
         self.rgb_files = natsorted(list((self.dataset_path).glob("*.png")))
         self.timestamps = np.arange(0, len(self.rgb_files)).astype(self.dtype) / 30.0


### PR DESCRIPTION
Hi @rmurai0610 :wave: !  

I read through all the code changes for this [commit ](https://github.com/rmurai0610/MASt3R-SLAM/commit/cfa18db255d98cbe221ec08364f7e7720231b68e) and found that specifying the camera's intrinsics externally is accomplished with the `--calib` argument and the `intrinsic.yaml` file, which can work fine!

However, adding too many arguments to paser in the `main.py` file makes the project trivial and the code less readable and dimensional. Also, the current implementation only outputs the config in `base.yaml` at [line](https://github.com/rmurai0610/MASt3R-SLAM/blob/cfa18db255d98cbe221ec08364f7e7720231b68e/main.py#L164), and the contents of the added `intrinsics.yaml` are not printed out.

It would be better to implement this requirement only through the **_inheritance_** feature of the yaml file. To that end, I've streamlined my code and submitted this PR.

This way It's possible to specify the camera intrinsic from the outside as described in [here](https://github.com/rmurai0610/MASt3R-SLAM/commit/17321de5dc2265e456368cb07c55077fa639487c), implemented only through the yaml file, something like this:
```bash
python main.py --dataset <path/to/video>.mp4 --config config/intrinsics.yaml
```
  
Very elegant and simple! :tada:

Since I didn't read all the project code, it's possible that the code in the PR potentially affects other parts, if so, please don't hesitate to let me know! If you test it without problems, merging this PR would be appreciated by me!
