### PR TITLE
Standardise eth3d dataset storage location

### DIFF
--- a/scripts/download_eth3d.sh
+++ b/scripts/download_eth3d.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-dest="datasets/eth3d"
+dest="datasets/eth3d/train"
 mkdir -p "$dest"
 
 sequences=(

--- a/scripts/download_eth3d.sh
+++ b/scripts/download_eth3d.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-dest="datasets/eth3d/train2"
+dest="datasets/eth3d"
 mkdir -p "$dest"
 
 sequences=(

--- a/scripts/eval_eth3d.sh
+++ b/scripts/eval_eth3d.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-dataset_path="datasets/eth3d/train/"
+dataset_path="datasets/eth3d"
 
 datasets=(
     plant_1

--- a/scripts/eval_eth3d.sh
+++ b/scripts/eval_eth3d.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-dataset_path="datasets/eth3d"
+dataset_path="datasets/eth3d/"
 
 datasets=(
     plant_1

--- a/scripts/eval_eth3d.sh
+++ b/scripts/eval_eth3d.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-dataset_path="datasets/eth3d/"
+dataset_path="datasets/eth3d/train/"
 
 datasets=(
     plant_1


### PR DESCRIPTION
The current `download_eth3d.sh` script downloads the eth3d data to `datasets/eth3d/train2/`. But the evaluation script (`eval_eth3d.sh`) looks for this data in `datasets/eth3d/train/`.

The eth3d dataset is the only one that has this file structure, and not just a `/datasets/xxx/` folder. So I've made changes to bring eth3d in line with how the other datasets are stored and retrieved for evaluation.