### PR TITLE
Add lower end hardware support

### DIFF
--- a/main.py
+++ b/main.py
@@ -156,6 +156,7 @@ if __name__ == "__main__":
     parser.add_argument("--save-as", default="default")
     parser.add_argument("--no-viz", action="store_true")
     parser.add_argument("--calib", default="")
+    parser.add_argument("--kf-buffer", default=512, type=int)
 
     args = parser.parse_args()
 
@@ -183,7 +184,7 @@ if __name__ == "__main__":
             intrinsics["calibration"],
         )
 
-    keyframes = SharedKeyframes(manager, h, w)
+    keyframes = SharedKeyframes(manager, h, w, args.kf_buffer)
     states = SharedStates(manager, h, w)
 
     if not args.no_viz:

--- a/mast3r_slam/visualization.py
+++ b/mast3r_slam/visualization.py
@@ -166,9 +166,10 @@ class Window(WindowEvents):
                     thickness=self.line_thickness * self.scale,
                 )
 
-            ptex, ctex, itex = self.textures[keyframe.frame_id]
-            if self.show_all:
-                self.render_pointmap(keyframe.T_WC.cpu(), w, h, ptex, ctex, itex)
+            if keyframe.frame_id in self.textures:
+                ptex, ctex, itex = self.textures[keyframe.frame_id]
+                if self.show_all:
+                    self.render_pointmap(keyframe.T_WC.cpu(), w, h, ptex, ctex, itex)
 
         if self.show_keyframe_edges:
             with self.states.lock:
@@ -190,27 +191,28 @@ class Window(WindowEvents):
             if config["use_calib"]:
                 curr_frame.K = self.keyframes.get_intrinsics()
             h, w = curr_frame.img_shape.flatten()
-            X = self.frame_X(curr_frame)
-            C = curr_frame.C.cpu().numpy().astype(np.float32)
-            if "curr" not in self.textures:
-                ptex = self.ctx.texture((w, h), 3, dtype="f4", alignment=4)
-                ctex = self.ctx.texture((w, h), 1, dtype="f4", alignment=4)
-                itex = self.ctx.texture((w, h), 3, dtype="f4", alignment=4)
-                self.textures["curr"] = ptex, ctex, itex
-            ptex, ctex, itex = self.textures["curr"]
-            ptex.write(X.tobytes())
-            ctex.write(C.tobytes())
-            itex.write(depth2rgb(X[..., -1], colormap="turbo"))
-            self.render_pointmap(
-                curr_frame.T_WC.cpu(),
-                w,
-                h,
-                ptex,
-                ctex,
-                itex,
-                use_img=True,
-                depth_bias=self.depth_bias,
-            )
+            if h != 0 and w != 0:
+                X = self.frame_X(curr_frame)
+                C = curr_frame.C.cpu().numpy().astype(np.float32)
+                if "curr" not in self.textures:
+                    ptex = self.ctx.texture((w, h), 3, dtype="f4", alignment=4)
+                    ctex = self.ctx.texture((w, h), 1, dtype="f4", alignment=4)
+                    itex = self.ctx.texture((w, h), 3, dtype="f4", alignment=4)
+                    self.textures["curr"] = ptex, ctex, itex
+                ptex, ctex, itex = self.textures["curr"]
+                ptex.write(X.tobytes())
+                ctex.write(C.tobytes())
+                itex.write(depth2rgb(X[..., -1], colormap="turbo"))
+                self.render_pointmap(
+                    curr_frame.T_WC.cpu(),
+                    w,
+                    h,
+                    ptex,
+                    ctex,
+                    itex,
+                    use_img=True,
+                    depth_bias=self.depth_bias,
+                )
 
         self.lines.render(self.camera)
         self.frustums.render(self.camera)


### PR DESCRIPTION
Thanks for the great work!

Related to #18, added a `--kf-buffer` cli argument to specify the buffer size for the `SharedKeyframes` class. But note that if the buffer size is too low, it may get a CUDA illegal memory access error:

```
Process Process-2:
Traceback (most recent call last):
  File "/home/lioqing/anaconda3/envs/mast3r-slam/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/home/lioqing/anaconda3/envs/mast3r-slam/lib/python3.11/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/lioqing/MASt3R-SLAM/mast3r_slam/visualization.py", line 440, in run_visualization
    window.render(current_time, delta)
  File "/home/lioqing/anaconda3/envs/mast3r-slam/lib/python3.11/site-packages/moderngl_window/context/base/window.py", line 742, in render
    self.render_func(time, frame_time)
  File "/home/lioqing/MASt3R-SLAM/mast3r_slam/visualization.py", line 154, in render
    keyframe = self.keyframes[kf_idx]
               ~~~~~~~~~~~~~~^^^^^^^^
  File "/home/lioqing/MASt3R-SLAM/mast3r_slam/frame.py", line 254, in __getitem__
    int(self.dataset_idx[idx]),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: CUDA error: an illegal memory access was encountered
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```

Additionally, when I am testing on my hardware (RTX 2060 Max-Q), the visualization seems to have some initialization (seems like race condition, not sure) issues with custom dataset (both mp4 and rgb images). These changes fixed it for me, they are just checks for a valid render texture before doing the renders.

https://github.com/LioQing/MASt3R-SLAM/blob/d5ceb75ceb5bfdf4951525cc21cf5d4b489b4f68/mast3r_slam/visualization.py#L169
```py
            if keyframe.frame_id in self.textures:
```

https://github.com/LioQing/MASt3R-SLAM/blob/d5ceb75ceb5bfdf4951525cc21cf5d4b489b4f68/mast3r_slam/visualization.py#L194
```py
            if h != 0 and w != 0:
```

I ran the code on WSL but I am requesting the pull to the main branch because I see the main branch is more up to date. If you think these changes are uneccessary feel free to close it.