### PR TITLE
[FEAT] Add MEI/omnidir camera model support to dataloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ screen.yaml
 *.pt
 *.ini
 notebooks/*
+
+.vscode/

--- a/config/intrinsics.yaml
+++ b/config/intrinsics.yaml
@@ -3,5 +3,8 @@ height: 480
 # With distortion (fx, fy, cx, cy, k1, k2, p1, p2)
 calibration:  [517.3, 516.5, 318.6, 255.3, 0.2624, -0.9531, -0.0054, 0.0026, 1.1633]
 
+# With distortion in MEI camera model (fx, fy, cx, cy, xi, k1, k2, p1, p2)
+# calibration:  [517.3, 516.5, 318.6, 255.3, 1.0, 0.2624, -0.9531, -0.0054, 0.0026, 1.1633]
+
 # Without distortion (fx, fy, cx, cy)
 # calibration:  [517.3, 516.5, 318.6, 255.3]


### PR DESCRIPTION
## Motivation

Initial implementation of support for MEI camera model parameters, enabling undistortion using camera parameters calibrated with this model.

## Modification

- Implement MEI and omnidir camera model support in `dataloader.py`.
  - Update `from_calib` to handle MEI calibration parameters.
  - Support dictionary and array formats for MEI calibration input.
  - Use `cv2.omnidir` for undistortion of MEI camera model.
  - Retain pinhole camera model as default.
- Update intrinsics.yaml with MEI calibration example.
- Add `.vscode/` folder to gitignore.

## Usage

Create a new file named `config/intrinsics_omnidir.yaml`:

```yaml
width: 1920
height: 1080

# With distortion in MEI camera model (fx, fy, cx, cy, xi, k1, k2, p1, p2)
calibration:
  - 1441.9160896991989
  - 1390.1791212926507
  - 953.1380538193248
  - 555.50824029929242
  - 1.3112230988388285
  - -0.24550852157878525
  - 0.017740962776894544
  - -0.00045286349158624514
  - -0.00029970814738975934
  ```
  
  Running on a video:
  
  ```shell
  python main.py --dataset <path/to/fisheye/video>.mp4 --config config/base.yaml --calib config/intrinsics_omnidir.yaml
  ```