### PR TITLE
Issue: Not compatible with RTX50XX as cm_120 is not supported (resolved)

### DIFF
--- a/mast3r_slam/backend/src/gn_kernels.cu
+++ b/mast3r_slam/backend/src/gn_kernels.cu
@@ -799,7 +799,7 @@ std::vector<torch::Tensor> gauss_newton_points_cuda(
 
     // Termination criteria
     // Need to specify this second argument otherwise ambiguous function call...
-    delta_norm = torch::linalg::linalg_norm(dx, std::optional<c10::Scalar>(), {}, false, {});
+    delta_norm = at::linalg_norm(dx, c10::nullopt, {}, false, c10::nullopt);
     if (delta_norm.item<float>() < delta_thresh) {
       break;
     }
@@ -1216,7 +1216,7 @@ std::vector<torch::Tensor> gauss_newton_rays_cuda(
 
     // Termination criteria
     // Need to specify this second argument otherwise ambiguous function call...
-    delta_norm = torch::linalg::linalg_norm(dx, std::optional<c10::Scalar>(), {}, false, {});
+    delta_norm = at::linalg_norm(dx, c10::nullopt, {}, false, c10::nullopt);
     if (delta_norm.item<float>() < delta_thresh) {
       break;
     }
@@ -1626,7 +1626,7 @@ std::vector<torch::Tensor> gauss_newton_calib_cuda(
 
     // Termination criteria
     // Need to specify this second argument otherwise ambiguous function call...
-    delta_norm = torch::linalg::linalg_norm(dx, std::optional<c10::Scalar>(), {}, false, {});
+    delta_norm = at::linalg_norm(dx, c10::nullopt, {}, false, c10::nullopt);
     if (delta_norm.item<float>() < delta_thresh) {
       break;
     }

--- a/mast3r_slam/backend/src/matching_kernels.cu
+++ b/mast3r_slam/backend/src/matching_kernels.cu
@@ -100,7 +100,7 @@ std::vector<torch::Tensor> refine_matches_cuda(
   torch::Tensor p1_new = torch::zeros(
     {batch_size, n, 2}, opts);
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(D11.type(), "refine_matches_kernel", ([&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(D11.scalar_type(), "refine_matches_kernel", ([&] {
     refine_matches_kernel<scalar_t><<<blocks, threads>>>(
       D11.packed_accessor32<scalar_t,4,torch::RestrictPtrTraits>(),
       D21.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,9 @@ extra_compile_args = {
 if has_cuda:
     from torch.utils.cpp_extension import CUDAExtension
 
+    cuda_version = torch.version.cuda
+    cuda_major, cuda_minor = map(int, cuda_version.split(".")[:2])
+
     sources.append("mast3r_slam/backend/src/gn_kernels.cu")
     sources.append("mast3r_slam/backend/src/matching_kernels.cu")
     extra_compile_args["nvcc"] = [
@@ -35,6 +38,13 @@ if has_cuda:
         "-gencode=arch=compute_80,code=sm_80",
         "-gencode=arch=compute_86,code=sm_86",
     ]
+
+    if (cuda_major, cuda_minor) >= (11, 8):
+        extra_compile_args["nvcc"].append("-gencode=arch=compute_90,code=sm_90")
+
+    if (cuda_major, cuda_minor) >= (12, 8):
+        extra_compile_args["nvcc"].append("-gencode=arch=compute_120,code=sm_120")
+
     ext_modules = [
         CUDAExtension(
             "mast3r_slam_backends",

--- a/thirdparty/mast3r/dust3r/croco/models/curope/kernels.cu
+++ b/thirdparty/mast3r/dust3r/croco/models/curope/kernels.cu
@@ -98,7 +98,7 @@ void rope_2d_cuda( torch::Tensor tokens, const torch::Tensor pos, const float ba
     const int N_BLOCKS = B * N; // each block takes care of H*D values
     const int SHARED_MEM = sizeof(float) * (D + D/4);
 
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(tokens.type(), "rope_2d_cuda", ([&] {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(tokens.scalar_type(), "rope_2d_cuda", ([&] {
         rope_2d_cuda_kernel<scalar_t> <<<N_BLOCKS, THREADS_PER_BLOCK, SHARED_MEM>>> (
             //tokens.data_ptr<scalar_t>(), 
             tokens.packed_accessor32<scalar_t,4,torch::RestrictPtrTraits>(),

--- a/thirdparty/mast3r/dust3r/croco/utils/misc.py
+++ b/thirdparty/mast3r/dust3r/croco/utils/misc.py
@@ -311,9 +311,9 @@ def load_model(args, model_without_ddp, optimizer, loss_scaler):
     if args.resume is not None:
         if args.resume.startswith('https'):
             checkpoint = torch.hub.load_state_dict_from_url(
-                args.resume, map_location='cpu', check_hash=True)
+                args.resume, map_location='cpu', check_hash=True, weights_only=False)
         else:
-            checkpoint = torch.load(args.resume, map_location='cpu')
+            checkpoint = torch.load(args.resume, map_location='cpu', weights_only=False)
         print("Resume checkpoint %s" % args.resume)
         model_without_ddp.load_state_dict(checkpoint['model'], strict=False)
         args.start_epoch = checkpoint['epoch'] + 1

--- a/thirdparty/mast3r/dust3r/dust3r/model.py
+++ b/thirdparty/mast3r/dust3r/dust3r/model.py
@@ -27,7 +27,7 @@ assert version.parse(hf_version_number) >= version.parse("0.22.0"), ("Outdated h
 def load_model(model_path, device, verbose=True):
     if verbose:
         print('... loading model from', model_path)
-    ckpt = torch.load(model_path, map_location='cpu')
+    ckpt = torch.load(model_path, map_location='cpu', weights_only=False)
     args = ckpt['args'].model.replace("ManyAR_PatchEmbed", "PatchEmbedDust3R")
     if 'landscape_only' not in args:
         args = args[:-1] + ', landscape_only=False)'

--- a/thirdparty/mast3r/mast3r/model.py
+++ b/thirdparty/mast3r/mast3r/model.py
@@ -21,7 +21,7 @@ inf = float('inf')
 def load_model(model_path, device, verbose=True):
     if verbose:
         print('... loading model from', model_path)
-    ckpt = torch.load(model_path, map_location='cpu')
+    ckpt = torch.load(model_path, map_location='cpu', weights_only=False)
     args = ckpt['args'].model.replace("ManyAR_PatchEmbed", "PatchEmbedDust3R")
     if 'landscape_only' not in args:
         args = args[:-1] + ', landscape_only=False)'

--- a/thirdparty/mast3r/mast3r/retrieval/processor.py
+++ b/thirdparty/mast3r/mast3r/retrieval/processor.py
@@ -67,7 +67,7 @@ class Retriever(object):
         # load the model
         assert os.path.isfile(modelname), modelname
         print(f'Loading retrieval model from {modelname}')
-        ckpt = torch.load(modelname, 'cpu')  # TODO from pretrained to download it automatically
+        ckpt = torch.load(modelname, 'cpu', weights_only=False)  # TODO from pretrained to download it automatically
         ckpt_args = ckpt['args']
         if backbone is None:
             backbone = AsymmetricMASt3R.from_pretrained(ckpt_args.pretrained)


### PR DESCRIPTION
## Issue:

As it stands, MAST3R-SLAM is not compatible with Blackwell Nvidia GPU architecture, as the only torch/cuda version supporting sm_120 architectures is 2.8.0+cu128. 
Some of the functions used in MAST3R-SLAM have been deprecated since torch 2.6. The proposed changes would make MAST3R-SLAM compatible with the blackwell architecture and the latest version of torch while retaining backward compatibility with older torch versions (to be tested, I don't have access to an older system, but I added the new architectures as a conditional based on the cuda version, so pretty sure everything is backward compatible). 

## Fixes:

- removed deprecated methods

  - change to dispatch on new `torch.scalar_type()` API instead of deprecated `torch.type()`
  - starting in torch2.6, `torch.load(..., weights_only=True)` (the new default) will refuse to deserialize any Python globals that arent explicitly allow-listed, thus explicitly setting `weights_only=False`
  - changed `torch::linalg::linalg_norm(dx, std::optional<c10::Scalar>(), {}, false, {});` to use `at::` namespace APIs that are more reliably resolved by nvcc. nvcc sometimes has trouble resolving some torch namespaces

- added sm_90 and sm_120 architecture to [setup.py](http://setup.py/) (conditonally on cuda version to retain backward compatibility).