### PR TITLE
Fix Mast3r for newer torch versions (required for RTX50xx GPUs)

### DIFF
--- a/thirdparty/mast3r/dust3r/croco/models/curope/kernels.cu
+++ b/thirdparty/mast3r/dust3r/croco/models/curope/kernels.cu
@@ -98,7 +98,7 @@ void rope_2d_cuda( torch::Tensor tokens, const torch::Tensor pos, const float ba
     const int N_BLOCKS = B * N; // each block takes care of H*D values
     const int SHARED_MEM = sizeof(float) * (D + D/4);
 
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(tokens.type(), "rope_2d_cuda", ([&] {
+    AT_DISPATCH_FLOATING_TYPES_AND2(at::kHalf, at::kBFloat16, tokens.scalar_type(), "rope_2d_cuda", ([&] {
         rope_2d_cuda_kernel<scalar_t> <<<N_BLOCKS, THREADS_PER_BLOCK, SHARED_MEM>>> (
             //tokens.data_ptr<scalar_t>(), 
             tokens.packed_accessor32<scalar_t,4,torch::RestrictPtrTraits>(),


### PR DESCRIPTION
It seems that building `curope` currently fails due to a dependency on older torch version, see [https://github.com/naver/mast3r/issues/125](https://github.com/naver/mast3r/issues/125). I need newer torch versions since I am using a RTX5090, which requires cuda 12.8. This fix was proposed in [this commit ](https://github.com/naver/croco/compare/743ee71a2a9bf57cea6832a9064a70a0597fcfcb...d7de0705845239092414480bd829228723bf20de#diff-cd9847161e67a14944a3b6ab29349f1b768367afc64a08f59252383db91c895d) and made it work for newer torch versions for me.